### PR TITLE
Fix python tests

### DIFF
--- a/python/shop.py
+++ b/python/shop.py
@@ -25,7 +25,8 @@ class Shop:
         if user.age <= 18:
             return False
         if not user.verified:
-            return True
+            # We should return FALSE here
+            return False
         else:
             return True
 

--- a/python/shop.py
+++ b/python/shop.py
@@ -25,7 +25,6 @@ class Shop:
         if user.age <= 18:
             return False
         if not user.verified:
-            # We should return FALSE here
             return False
         else:
             return True

--- a/python/shop.py
+++ b/python/shop.py
@@ -19,6 +19,48 @@ class User:
     verified: bool
 
 
+@dataclass
+class UserBuilder:
+    name: str
+    email: str
+    age: int
+    address: Address
+    verified: bool
+
+    def __init__(self):
+        self.name = "bob"
+        self.email = "bob@domain.tld"
+
+    def with_name(self, name):
+        self.name = name
+        return self
+
+    def with_email(self, email):
+        self.email = email
+        return self
+
+    def with_age(self, age):
+        self.age = age
+        return self
+
+    def with_verified_status(self, verified):
+        self.verified = verified
+        return self
+
+    def with_address(self, address):
+        self.address = address
+        return self
+
+    def build(self):
+        return User(
+            name=self.name,
+            email=self.email,
+            age=self.age,
+            address=self.address,
+            verified=self.verified,
+        )
+
+
 class Shop:
     @classmethod
     def can_order(cls, user):

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+
 from shop import Address
 
 

--- a/python/tests/test_shop.py
+++ b/python/tests/test_shop.py
@@ -1,13 +1,13 @@
-from shop import Shop, User
+from shop import Shop, UserBuilder
 
 
 def test_happy_path(fsf_address):
-    user = User(
-        name="bob",
-        email="bob@domain.tld",
-        age=25,
-        address=fsf_address,
-        verified=True,
+    user = (
+        UserBuilder()
+        .with_age(25)
+        .with_verified_status(True)
+        .with_address(fsf_address)
+        .build()
     )
 
     assert Shop.can_order(user)
@@ -15,12 +15,12 @@ def test_happy_path(fsf_address):
 
 
 def test_minors_cannot_order_from_the_shop(fsf_address):
-    user = User(
-        name="bob",
-        email="bob@domain.tld",
-        age=16,
-        address=fsf_address,
-        verified=True,
+    user = (
+        UserBuilder()
+        .with_age(16)
+        .with_verified_status(True)
+        .with_address(fsf_address)
+        .build()
     )
 
     assert not Shop.can_order(user)
@@ -28,28 +28,28 @@ def test_minors_cannot_order_from_the_shop(fsf_address):
 
 def test_cannot_order_if_not_verified(fsf_address):
     """
-    Before the modifications, the test passed because it received 
-    the false value for tests under 18 years of age. We need to 
+    Before the modifications, the test passed because it received
+    the false value for tests under 18 years of age. We need to
     set an age greater than 18 to check the "verified" field correctly.
     """
-    user = User(
-        name="bob",
-        email="bob@domain.tld",
-        age=19,
-        address=fsf_address,
-        verified=False,
+    user = (
+        UserBuilder()
+        .with_age(19)
+        .with_verified_status(False)
+        .with_address(fsf_address)
+        .build()
     )
 
     assert not Shop.can_order(user)
 
 
 def test_foreigners_must_be_foreign_fee(paris_address):
-    user = User(
-        name="bob",
-        email="bob@domain.tld",
-        age=25,
-        address=paris_address,
-        verified=False,
+    user = (
+        UserBuilder()
+        .with_age(25)
+        .with_verified_status(False)
+        .with_address(paris_address)
+        .build()
     )
 
     assert Shop.must_pay_foreign_fee(user)

--- a/python/tests/test_shop.py
+++ b/python/tests/test_shop.py
@@ -27,10 +27,15 @@ def test_minors_cannot_order_from_the_shop(fsf_address):
 
 
 def test_cannot_order_if_not_verified(fsf_address):
+    """
+    Before the modifications, the test passed because it received 
+    the false value for tests under 18 years of age. We need to 
+    set an age greater than 18 to check the "verified" field correctly.
+    """
     user = User(
         name="bob",
         email="bob@domain.tld",
-        age=16,
+        age=19,
         address=fsf_address,
         verified=False,
     )


### PR DESCRIPTION
Before the modifications, the "test_cannot_order_if_not_verified" test was passing because it was receiving a false value for the age less than 18 test. To verify the "verified" field correctly, we need to set an age greater than 18 to trigger the following condition 

```py
if not user.verified:
    return False
```